### PR TITLE
Upgrade webdrivermanager

### DIFF
--- a/.github/workflows/build-selenium.yml
+++ b/.github/workflows/build-selenium.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Build Selenium Jar
         run: |
-          export MAVEN_OPTS="-Xmx1024m -XX:MaxPermSize=512m"
+          export MAVEN_OPTS="-Xmx3G -XX:MaxPermSize=512m"
           cd inst/selenium
           mvn package
           cp target/selenium-1.0.0-jar-with-dependencies.jar selenium.jar

--- a/.github/workflows/build-selenium.yml
+++ b/.github/workflows/build-selenium.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Build Selenium Jar
         run: |
-          export MAVEN_OPTS="-Xmx512m -XX:MaxPermSize=128m"
+          export MAVEN_OPTS="-Xmx1024m -XX:MaxPermSize=512m"
           cd inst/selenium
           mvn package
           cp target/selenium-1.0.0-jar-with-dependencies.jar selenium.jar

--- a/.github/workflows/build-selenium.yml
+++ b/.github/workflows/build-selenium.yml
@@ -35,6 +35,7 @@ jobs:
 
       - name: Build Selenium Jar
         run: |
+          export MAVEN_OPTS="-Xmx512m -XX:MaxPermSize=128m"
           cd inst/selenium
           mvn package
           cp target/selenium-1.0.0-jar-with-dependencies.jar selenium.jar
@@ -45,4 +46,3 @@ jobs:
         run: |
           git commit -m 'Maven build (GitHub Actions)' || echo "No Maven changes to commit"
           git push https://${{github.actor}}:${{secrets.GITHUB_TOKEN}}@github.com/${{github.repository}}.git HEAD:${{ github.ref }} || echo "No changes to push"
-

--- a/.github/workflows/build-selenium.yml
+++ b/.github/workflows/build-selenium.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Build Selenium Jar
         run: |
-          export MAVEN_OPTS="-Xmx3G -XX:MaxPermSize=512m"
+          export MAVEN_OPTS="-Xmx4G -XX:MaxPermSize=2G"
           cd inst/selenium
           mvn package
           cp target/selenium-1.0.0-jar-with-dependencies.jar selenium.jar

--- a/.github/workflows/build-selenium.yml
+++ b/.github/workflows/build-selenium.yml
@@ -19,13 +19,13 @@ jobs:
       - uses: actions/checkout@v1
         name: Git Pull
 
-      # - uses: actions/cache@v1
-      #   name: Maven Cache
-      #   with:
-      #     path: ~/.m2/repository
-      #     key: ${{ runner.config.os }}-maven-${{ hashFiles('**/pom.xml') }}
-      #     restore-keys: |
-      #       ${{ runner.config.os }}-maven-
+      - uses: actions/cache@v1
+        name: Maven Cache
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.config.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.config.os }}-maven-
 
       - name: Git Config
         run: |
@@ -35,9 +35,8 @@ jobs:
 
       - name: Build Selenium Jar
         run: |
-          export MAVEN_OPTS="-Xmx6G -XX:MaxPermSize=6G"
           cd inst/selenium
-          mvn -X package
+          mvn package
           cp target/selenium-1.0.0-jar-with-dependencies.jar selenium.jar
           git add selenium.jar
 
@@ -46,3 +45,4 @@ jobs:
         run: |
           git commit -m 'Maven build (GitHub Actions)' || echo "No Maven changes to commit"
           git push https://${{github.actor}}:${{secrets.GITHUB_TOKEN}}@github.com/${{github.repository}}.git HEAD:${{ github.ref }} || echo "No changes to push"
+

--- a/.github/workflows/build-selenium.yml
+++ b/.github/workflows/build-selenium.yml
@@ -19,13 +19,13 @@ jobs:
       - uses: actions/checkout@v1
         name: Git Pull
 
-      - uses: actions/cache@v1
-        name: Maven Cache
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.config.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.config.os }}-maven-
+      # - uses: actions/cache@v1
+      #   name: Maven Cache
+      #   with:
+      #     path: ~/.m2/repository
+      #     key: ${{ runner.config.os }}-maven-${{ hashFiles('**/pom.xml') }}
+      #     restore-keys: |
+      #       ${{ runner.config.os }}-maven-
 
       - name: Git Config
         run: |
@@ -37,7 +37,7 @@ jobs:
         run: |
           export MAVEN_OPTS="-Xmx6G -XX:MaxPermSize=6G"
           cd inst/selenium
-          mvn package
+          mvn -X package
           cp target/selenium-1.0.0-jar-with-dependencies.jar selenium.jar
           git add selenium.jar
 

--- a/.github/workflows/build-selenium.yml
+++ b/.github/workflows/build-selenium.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Build Selenium Jar
         run: |
-          export MAVEN_OPTS="-Xmx4G -XX:MaxPermSize=2G"
+          export MAVEN_OPTS="-Xmx6G -XX:MaxPermSize=6G"
           cd inst/selenium
           mvn package
           cp target/selenium-1.0.0-jar-with-dependencies.jar selenium.jar

--- a/inst/selenium/pom.xml
+++ b/inst/selenium/pom.xml
@@ -12,7 +12,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <selenium.version>3.141.59</selenium.version>
         <kotlin.version>1.3.61</kotlin.version>
-        <webdrivermanager.version>5.3.3</webdrivermanager.version>
+        <webdrivermanager.version>4.3.1</webdrivermanager.version>
         <main.class>com.rstudio.seleniumRunner.MainKt</main.class>
     </properties>
 

--- a/inst/selenium/pom.xml
+++ b/inst/selenium/pom.xml
@@ -12,7 +12,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <selenium.version>3.141.59</selenium.version>
         <kotlin.version>1.3.61</kotlin.version>
-        <webdrivermanager.version>4.3.1</webdrivermanager.version>
+        <webdrivermanager.version>5.3.3</webdrivermanager.version>
         <main.class>com.rstudio.seleniumRunner.MainKt</main.class>
     </properties>
 


### PR DESCRIPTION
This PR bumps selenium's webdrivermanager dependency in the jar file (in hope of fixing this shinycoreci issue):

https://github.com/rstudio/shinycoreci/actions/runs/6101414651/job/16557727294#step:14:41062
https://howtodoinjava.com/java/exception-handling/this-version-of-chromedriver-only-supports-chrome-version/

I couldn't get `.github/workflows/build-selenium.yml` to build the jar file properly (even with a large amount of heap space, it's still complaining it's not enough), so I ended up just building the jar file locally on my mac.

I'm gonna merge this just for now to see if it improves things (if it does, maybe the workflow that builds the jar should switch to macOS?)